### PR TITLE
raw_bsd was checking non syscall error agains syscall errno.

### DIFF
--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -76,8 +76,10 @@ func listenPacket(ifi *net.Interface, proto Protocol) (*packetConn, error) {
 		}
 
 		// Device is busy, try the next one
-		if err == syscall.EBUSY {
-			continue
+		if perr, ok := err.(*os.PathError); ok {
+			if perr.Err.(syscall.Errno) == syscall.EBUSY {
+				continue
+			}
 		}
 
 		return nil, err


### PR DESCRIPTION
raw_bsd was checking non syscall error agains syscall errno which would lead to issues when BPF0 is busy. This change will allow retry on BPF 1-9 if 0 is busy.

os.OpenFile returns a path error and not a syscall error. As such, comparing the error returned to syscall.EBUSY will always return false even when the returned error is a resource busy error. This change makes it so the busy error is checked for and in the case the resource is busy the next BPF resource will be tried instead.

Tested on OS X, where I was having an issue with the raw library always quitting after returning an error of BPF0 being busy.