### PR TITLE
add data link layer multicast join/drop for Linux and BSD

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -103,6 +103,12 @@ func (c *Conn) SetPromiscuous(b bool) error {
 	return c.p.SetPromiscuous(b)
 }
 
+// SetMulticast joins or drops membership of data link layer multicast address on interface,
+// allowing it to recieve multicast traffic.
+func (c *Conn) SetMulticast(b bool, addr net.HardwareAddr) error {
+	return c.p.SetMulticast(b, addr)
+}
+
 // A Protocol is a network protocol constant which identifies the type of
 // traffic a raw socket should send and receive.
 type Protocol uint16

--- a/raw_others.go
+++ b/raw_others.go
@@ -66,3 +66,8 @@ func (p *packetConn) SetBPF(filter []bpf.RawInstruction) error {
 func (p *packetConn) SetPromiscuous(b bool) error {
 	return ErrNotImplemented
 }
+
+// SetMulticast is not currently implemented on this platform.
+func (p *packetConn) SetMulticast(b bool, addr net.HardwareAddr) error {
+	return ErrNotImplemented
+}


### PR DESCRIPTION
Add SetMulticast(b bool, addr net.Addr) to Linux and BSD. Stub in others with ErrNotImplemented.

Linux implementation through setsockopt(), as such any multicast groups joined will automatically be dropped on socket close.

BSD implementation though dummy syscall.Socket and ioctl. Each multicast group joined/dropped is added/deleted to/from a net.HardwareAddr slice inside the Addr structure. This keeps track of the number of added hardware addresses at the time of Conn.Close(). Inside the .Close() function any remaining hardware addresses are dropped prior to exiting.