### PR TITLE
Set read timeout on file descriptor

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -22,7 +22,7 @@ const (
 
 	// Maximum read timeout per syscall.
 	// It is required because read/recvfrom won't be interrupted on closing of the file descriptor.
-	readTimeout time.Duration = time.Millisecond * 200
+	readTimeout = 200 * time.Millisecond
 )
 
 var (

--- a/raw.go
+++ b/raw.go
@@ -19,6 +19,10 @@ const (
 
 	// ProtocolWoL specifies the Wake-on-LAN protocol.
 	ProtocolWoL Protocol = 0x0842
+
+	// Maximum read timeout per syscall.
+	// It is required because read/recvfrom won't be interrupted on closing of the file descriptor.
+	readTimeout time.Duration = time.Millisecond * 200
 )
 
 var (

--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -143,12 +143,9 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 			}
 		}
 
-		tv := &syscall.Timeval{
-			Sec:  int64(timeout / time.Second),
-			Usec: int64(timeout % time.Second / time.Microsecond),
-		}
+		tv := newTimeval(timeout)
 
-		if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(p.fd), syscall.BIOCSRTIMEOUT, uintptr(unsafe.Pointer(tv))); err != 0 {
+		if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(p.fd), syscall.BIOCSRTIMEOUT, uintptr(unsafe.Pointer(&tv))); err != 0 {
 			return 0, nil, syscall.Errno(err)
 		}
 

--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -153,6 +153,7 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 		}
 
 		// Attempt to receive on socket
+		// The read sycall will NOT be interrupted by closing of the socket
 		n, err = syscall.Read(p.fd, buf)
 		if err != nil {
 			return n, nil, err

--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -128,6 +128,8 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	p.timeoutMu.Unlock()
 
 	if hasTimeout && timeout < time.Microsecond {
+		// A timeout less than a microsend results in a zero Timeval
+		// that disables the timeout. Return a timeout error in this case.
 		return 0, nil, &timeoutError{}
 	}
 

--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -14,7 +14,6 @@ import (
 	"unsafe"
 
 	"golang.org/x/net/bpf"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -144,7 +143,7 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 			}
 		}
 
-		tv := &unix.Timeval{
+		tv := &syscall.Timeval{
 			Sec:  int64(timeout / time.Second),
 			Usec: int64(timeout % time.Second / time.Microsecond),
 		}

--- a/raw_linux.go
+++ b/raw_linux.go
@@ -125,12 +125,12 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 			}
 		}
 
-		tv := &unix.Timeval{
+		tv := &syscall.Timeval{
 			Sec:  int64(timeout / time.Second),
 			Usec: int64(timeout % time.Second / time.Microsecond),
 		}
 
-		err := unix.SetsockoptTimeval(int(p.s.FD()), unix.SOL_SOCKET, unix.SO_RCVTIMEO, tv)
+		err := syscall.SetsockoptTimeval(p.s.FD(), syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, tv)
 		if err != nil {
 			return 0, nil, err
 		}

--- a/raw_linux.go
+++ b/raw_linux.go
@@ -130,13 +130,14 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	for {
 		// Attempt to receive on socket
 		n, addr, err = p.s.Recvfrom(b, 0)
+
+		if err == syscall.EAGAIN {
+			return n, nil, &timeoutError{}
+		}
 		if err != nil {
 			n = 0
 			// Return on error
 			return n, nil, err
-		}
-		if n == 0 {
-			return n, nil, &timeoutError{}
 		}
 
 		// Got data, cancel the deadline

--- a/raw_linux.go
+++ b/raw_linux.go
@@ -19,10 +19,6 @@ var (
 	_ net.PacketConn = &packetConn{}
 )
 
-const (
-	readInterval time.Duration = time.Millisecond * 200
-)
-
 // packetConn is the Linux-specific implementation of net.PacketConn for this
 // package.
 type packetConn struct {

--- a/raw_linux.go
+++ b/raw_linux.go
@@ -107,6 +107,8 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	p.timeoutMu.Unlock()
 
 	if hasTimeout && timeout < time.Microsecond {
+		// A timeout less than a microsend results in a zero Timeval
+		// that disables the timeout. Return a timeout error in this case.
 		return 0, nil, &timeoutError{}
 	}
 

--- a/raw_linux.go
+++ b/raw_linux.go
@@ -136,6 +136,7 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 		}
 
 		// Attempt to receive on socket
+		// The recvfrom sycall will NOT be interrupted by closing of the socket
 		n, addr, err = p.s.Recvfrom(b, 0)
 
 		if err == syscall.EAGAIN {

--- a/timeval.go
+++ b/timeval.go
@@ -1,0 +1,15 @@
+// +build !darwin
+
+package raw
+
+import (
+	"syscall"
+	"time"
+)
+
+func newTimeval(timeout time.Duration) syscall.Timeval {
+	return syscall.Timeval{
+		Sec:  int64(timeout / time.Second),
+		Usec: int64(timeout % time.Second / time.Microsecond),
+	}
+}

--- a/timeval_darwin.go
+++ b/timeval_darwin.go
@@ -1,0 +1,13 @@
+package raw
+
+import (
+	"syscall"
+	"time"
+)
+
+func newTimeval(timeout time.Duration) syscall.Timeval {
+	return syscall.Timeval{
+		Sec:  int64(timeout / time.Second),
+		Usec: int32(timeout % time.Second / time.Microsecond),
+	}
+}


### PR DESCRIPTION
Using `poll` before `read` is simple and works with timeouts.