### PR TITLE
raw: time out on Linux when deadline has passed

### DIFF
--- a/raw_linux.go
+++ b/raw_linux.go
@@ -278,8 +278,8 @@ func (s *sysSocket) SetSockopt(level, name int, v unsafe.Pointer, l uint32) erro
 }
 func (s *sysSocket) SetTimeout(timeout time.Duration) error {
 	tv := newTimeval(timeout)
-	if tv.Nano() == 0 {
-		// A zero timeout disables the timeout. Return a timeout error in this case.
+	if tv.Nano() <= 0 {
+		// A zero or negative timeout disables the timeout. Return a timeout error in this case.
 		return &timeoutError{}
 	}
 	return syscall.SetsockoptTimeval(s.fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)


### PR DESCRIPTION
/cc @corny 

Without this, I'm seeing `EDOM` on Linux.

```
[zsh|matt@nerr-2]:~/src/github.com/mdlayher/arp/cmd/arpc 0 *(master) ± time sudo ./arpc -d 1s -ip 192.168.1.3                 
2017/11/07 11:56:29 numerical argument out of domain
sudo ./arpc -d 1s -ip 192.168.1.3  0.00s user 0.01s system 1% cpu 1.050 total
```

With my patch:

```
[zsh|matt@nerr-2]:~/src/github.com/mdlayher/arp/cmd/arpc 0 *(master) ± time sudo ./arpc -d 1s -ip 192.168.1.3
2017/11/07 11:57:00 i/o timeout
sudo ./arpc -d 1s -ip 192.168.1.3  0.00s user 0.02s system 1% cpu 1.046 total
```