### PR TITLE
Move check of zero time value to newTimeval

### DIFF
--- a/raw_linux.go
+++ b/raw_linux.go
@@ -272,10 +272,9 @@ func (s *sysSocket) SetSockopt(level, name int, v unsafe.Pointer, l uint32) erro
 	return err
 }
 func (s *sysSocket) SetTimeout(timeout time.Duration) error {
-	tv := newTimeval(timeout)
-	if tv.Nano() <= 0 {
-		// A zero or negative timeout disables the timeout. Return a timeout error in this case.
-		return &timeoutError{}
+	tv, err := newTimeval(timeout)
+	if err != nil {
+		return err
 	}
-	return syscall.SetsockoptTimeval(s.fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
+	return syscall.SetsockoptTimeval(s.fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, tv)
 }

--- a/timeval.go
+++ b/timeval.go
@@ -7,9 +7,14 @@ import (
 	"time"
 )
 
-func newTimeval(timeout time.Duration) syscall.Timeval {
-	return syscall.Timeval{
+// newTimeval transforms a duration into a syscall.Timeval struct.
+// An error is returned in case of zero time value.
+func newTimeval(timeout time.Duration) (*syscall.Timeval, error) {
+	if timeout < time.Microsecond {
+		return nil, &timeoutError{}
+	}
+	return &syscall.Timeval{
 		Sec:  int64(timeout / time.Second),
 		Usec: int64(timeout % time.Second / time.Microsecond),
-	}
+	}, nil
 }

--- a/timeval_darwin.go
+++ b/timeval_darwin.go
@@ -5,9 +5,14 @@ import (
 	"time"
 )
 
-func newTimeval(timeout time.Duration) syscall.Timeval {
-	return syscall.Timeval{
+// newTimeval transforms a duration into a syscall.Timeval struct.
+// An error is returned in case of zero time value.
+func newTimeval(timeout time.Duration) (*syscall.Timeval, error) {
+	if timeout < time.Microsecond {
+		return nil, &timeoutError{}
+	}
+	return &syscall.Timeval{
 		Sec:  int64(timeout / time.Second),
 		Usec: int32(timeout % time.Second / time.Microsecond),
-	}
+	}, nil
 }


### PR DESCRIPTION
A negative time value should also result in an error on non Linux systems.