### PR TITLE
linux: allow listening on all interfaces

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -28,6 +28,7 @@ var _ net.Addr = &Addr{}
 // their hardware addresses.
 type Addr struct {
 	HardwareAddr net.HardwareAddr
+	Ifi int
 }
 
 // Network returns the address's network name, "raw".


### PR DESCRIPTION
This commit will allow listening on all interfaces by specifying nil
for the interface.

I have not looked at BSD properly, but it appears, that on BSD the BPF filter is used to filter on interfaces and not setting the interface part of the BPF filter should equal the result. However, I lack the knowledge to prperly judge the effects of such a change.
