### PR TITLE
Syscall6 returns errno not error

### DIFF
--- a/raw_linux.go
+++ b/raw_linux.go
@@ -269,7 +269,10 @@ func (s *sysSocket) Sendto(p []byte, flags int, to syscall.Sockaddr) error {
 }
 func (s *sysSocket) SetSockopt(level, name int, v unsafe.Pointer, l uint32) error {
 	_, _, err := syscall.Syscall6(syscall.SYS_SETSOCKOPT, uintptr(s.fd), uintptr(level), uintptr(name), uintptr(v), uintptr(l), 0)
-	return err
+	if err != 0 {
+		return syscall.Errno(err)
+	}
+	return nil
 }
 func (s *sysSocket) SetTimeout(timeout time.Duration) error {
 	tv, err := newTimeval(timeout)


### PR DESCRIPTION
- convert errno to error if non-zero otherwise no error. Without this SetBPF returns failure even though it succeeded (err == 0).