### PR TITLE
Fix build for ARM

### DIFF
--- a/timeval.go
+++ b/timeval.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,!arm
 
 package raw
 

--- a/timeval_arm.go
+++ b/timeval_arm.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build arm
 
 package raw
 
@@ -14,7 +14,7 @@ func newTimeval(timeout time.Duration) (*syscall.Timeval, error) {
 		return nil, &timeoutError{}
 	}
 	return &syscall.Timeval{
-		Sec:  int64(timeout / time.Second),
+		Sec:  int32(timeout / time.Second),
 		Usec: int32(timeout % time.Second / time.Microsecond),
 	}, nil
 }


### PR DESCRIPTION
ARM needs int32 in the syscall.Timeval, split it out just like the
_darwin one and add some build tags.

Fixes https://github.com/google/metallb/issues/49