### PR TITLE
support mips/mipsle archs that also have 32 bit timeval members

### DIFF
--- a/timeval.go
+++ b/timeval.go
@@ -1,4 +1,4 @@
-// +build !darwin,!arm,!windows
+// +build !darwin,!arm,!windows,!mipsle,!mips
 
 package raw
 

--- a/timeval32.go
+++ b/timeval32.go
@@ -1,4 +1,4 @@
-// +build arm
+// +build arm mipsle mips
 
 package raw
 


### PR DESCRIPTION
To build for mips or mipsle, the same timeval changes are required as for arm.