### PR TITLE
raw: add Config.NoTimeouts option, implement on Linux

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -112,7 +112,12 @@ func (c *Conn) SetPromiscuous(b bool) error {
 // A nil Config is equivalent to the default configuration: send and receive
 // data at the network interface device driver level (usually raw Ethernet frames).
 func ListenPacket(ifi *net.Interface, proto uint16, cfg *Config) (*Conn, error) {
-	p, err := listenPacket(ifi, proto, cfg)
+	// A nil config is an empty Config.
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	p, err := listenPacket(ifi, proto, *cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -127,6 +132,17 @@ type Config struct {
 	// Linux only: call socket(7) with SOCK_DGRAM instead of SOCK_RAW.
 	// Has no effect on other operating systems.
 	LinuxSockDGRAM bool
+
+	// Experimental: Linux only (for now, but can be ported to BSD):
+	// disables repeated socket reads due to internal timeouts, at the expense
+	// of losing the ability to cancel a ReadFrom operation by calling the Close
+	// method of the net.PacketConn.
+	//
+	// Not recommended for programs which may need to open and close multiple
+	// sockets during program runs.  This may save some CPU time by avoiding a
+	// busy loop for programs which do not need timeouts, or programs which keep
+	// a single socket open for the entire duration of the program.
+	NoTimeouts bool
 }
 
 // htons converts a short (uint16) from host-to-network byte order.

--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -63,8 +63,9 @@ type packetConn struct {
 
 // listenPacket creates a net.PacketConn which can be used to send and receive
 // data at the device driver level.
-func listenPacket(ifi *net.Interface, proto uint16, _ *Config) (*packetConn, error) {
+func listenPacket(ifi *net.Interface, proto uint16, _ Config) (*packetConn, error) {
 	// Config is, as of now, unused on BSD.
+	// TODO(mdlayher): consider porting NoTimeouts option to BSD if it pans out.
 
 	var f *os.File
 	var err error


### PR DESCRIPTION
For an internal use case at DigitalOcean, we don't need the timeout capabilities of this package.  With timeouts, system calls are performed repeatedly to keep checking the socket for readiness.

This implements a new configuration option (on Linux only for now, but the same could be ported to BSD) that completely disables setting socket timeouts, avoiding a syscall busy loop.