### PR TITLE
raw: use runtime epoll support

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -10,12 +10,6 @@ import (
 	"golang.org/x/net/bpf"
 )
 
-const (
-	// Maximum read timeout per syscall.
-	// It is required because read/recvfrom won't be interrupted on closing of the file descriptor.
-	readTimeout = 200 * time.Millisecond
-)
-
 var (
 	// ErrNotImplemented is returned when certain functionality is not yet
 	// implemented for the host operating system.
@@ -149,17 +143,6 @@ type Config struct {
 	// Has no effect on other operating systems.
 	LinuxSockDGRAM bool
 
-	// Experimental: Linux only (for now, but can be ported to BSD):
-	// disables repeated socket reads due to internal timeouts, at the expense
-	// of losing the ability to cancel a ReadFrom operation by calling the Close
-	// method of the net.PacketConn.
-	//
-	// Not recommended for programs which may need to open and close multiple
-	// sockets during program runs.  This may save some CPU time by avoiding a
-	// busy loop for programs which do not need timeouts, or programs which keep
-	// a single socket open for the entire duration of the program.
-	NoTimeouts bool
-
 	// Linux only: do not accumulate packet socket statistic counters.  Packet
 	// socket statistics are reset on each call to retrieve them via getsockopt,
 	// but this package's default behavior is to continue accumulating the
@@ -167,16 +150,3 @@ type Config struct {
 	// resetting statistics on each call to Stats, set this value to true.
 	NoCumulativeStats bool
 }
-
-// Copyright (c) 2012 The Go Authors. All rights reserved.
-// Source code in this file is based on src/net/interface_linux.go,
-// from the Go standard library.  The Go license can be found here:
-// https://golang.org/LICENSE.
-
-// Taken from:
-// https://github.com/golang/go/blob/master/src/net/net.go#L417-L421.
-type timeoutError struct{}
-
-func (e *timeoutError) Error() string   { return "i/o timeout" }
-func (e *timeoutError) Timeout() bool   { return true }
-func (e *timeoutError) Temporary() bool { return true }

--- a/raw_linux_test.go
+++ b/raw_linux_test.go
@@ -351,41 +351,6 @@ func Test_packetConnSetBPF(t *testing.T) {
 	}
 }
 
-// Test that timeouts are not set when they are disabled.
-
-type setTimeoutSocket struct {
-	setTimeout func(timeout time.Duration) error
-	noopSocket
-}
-
-func (s *setTimeoutSocket) Recvfrom(p []byte, flags int) (int, unix.Sockaddr, error) {
-	return 0, &unix.SockaddrLinklayer{
-		Halen: 6,
-	}, nil
-}
-
-func (s *setTimeoutSocket) SetTimeout(timeout time.Duration) error {
-	return s.setTimeout(timeout)
-}
-
-func Test_packetConnNoTimeouts(t *testing.T) {
-	s := &setTimeoutSocket{
-		setTimeout: func(_ time.Duration) error {
-			panic("a timeout was set")
-		},
-	}
-
-	p := &packetConn{
-		s:          s,
-		noTimeouts: true,
-	}
-
-	buf := make([]byte, 64)
-	if _, _, err := p.ReadFrom(buf); err != nil {
-		t.Fatalf("failed to read: %v", err)
-	}
-}
-
 func Test_packetConn_handleStats(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -446,9 +411,10 @@ type noopSocket struct{}
 
 func (noopSocket) Bind(sa unix.Sockaddr) error                                   { return nil }
 func (noopSocket) Close() error                                                  { return nil }
-func (noopSocket) FD() int                                                       { return 0 }
 func (noopSocket) GetSockopt(level, name int, v unsafe.Pointer, l uintptr) error { return nil }
 func (noopSocket) Recvfrom(p []byte, flags int) (int, unix.Sockaddr, error)      { return 0, nil, nil }
 func (noopSocket) Sendto(p []byte, flags int, to unix.Sockaddr) error            { return nil }
 func (noopSocket) SetSockopt(level, name int, v unsafe.Pointer, l uint32) error  { return nil }
-func (noopSocket) SetTimeout(timeout time.Duration) error                        { return nil }
+func (noopSocket) SetDeadline(timeout time.Time) error                           { return nil }
+func (noopSocket) SetReadDeadline(timeout time.Time) error                       { return nil }
+func (noopSocket) SetWriteDeadline(timeout time.Time) error                      { return nil }

--- a/timeout_bsd.go
+++ b/timeout_bsd.go
@@ -1,0 +1,26 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package raw
+
+import (
+	"time"
+)
+
+const (
+	// Maximum read timeout per syscall.
+	// It is required because read/recvfrom won't be interrupted on closing of the file descriptor.
+	readTimeout = 200 * time.Millisecond
+)
+
+// Copyright (c) 2012 The Go Authors. All rights reserved.
+// Source code in this file is based on src/net/interface_linux.go,
+// from the Go standard library.  The Go license can be found here:
+// https://golang.org/LICENSE.
+
+// Taken from:
+// https://github.com/golang/go/blob/master/src/net/net.go#L417-L421.
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }

--- a/timeval.go
+++ b/timeval.go
@@ -1,4 +1,4 @@
-// +build !darwin,!arm,!windows,!mipsle,!mips,!386
+// +build !darwin,!arm,!windows,!mipsle,!mips,!386,!linux
 
 package raw
 

--- a/timeval32.go
+++ b/timeval32.go
@@ -1,4 +1,5 @@
 // +build arm mipsle mips 386
+// +build !linux
 
 package raw
 


### PR DESCRIPTION
This allows us to call Close() while an existing Read/Write call is in
progress.

Yeah, this is ugly af.