### PR TITLE
raw: allow specifying a filter at creation

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -149,4 +149,8 @@ type Config struct {
 	// statistics internally per Conn.  To use the Linux default behavior of
 	// resetting statistics on each call to Stats, set this value to true.
 	NoCumulativeStats bool
+
+	// Linux only: initial filter to apply to the connection. This avoids
+	// capturing random packets before SetBPF is called.
+	Filter []bpf.RawInstruction
 }


### PR DESCRIPTION
Packet filtering on Linux raw sockets suffers from a race condition:
packets are queued on a raw socket as soon as it is created. Attaching
a filter via SetBPF does not clear the queue, and so the next ReadFrom
after SetBPF may return a random packet.

Fix this by not specifying a protocol at socket creation time, which
prevents the socket from capturing packets from the get go. We can
then attach a filter. Finally, we call Bind which enables capturing
packets for the protocol requested by the user.

See [1] for more information on the issue.

1: https://github.com/the-tcpdump-group/libpcap/blob/4f2b0f5befaa75c18a68a6849c759fe94c885727/pcap-linux.c#L7501