### PR TITLE
Export SetBPFDirection

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -86,6 +86,11 @@ func (c *Conn) SetBPF(filter []bpf.RawInstruction) error {
 	return c.p.SetBPF(filter)
 }
 
+// SetBPFDirection can be used to enable outbound packet processing
+func (c *Conn) SetBPFDirection(direction int) error {
+	return c.p.SetBPFDirection(direction)
+}
+
 // SetPromiscuous enables or disables promiscuous mode on the interface, allowing it
 // to receive traffic that is not addressed to the interface.
 func (c *Conn) SetPromiscuous(b bool) error {

--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -217,6 +217,11 @@ func (p *packetConn) SetBPF(filter []bpf.RawInstruction) error {
 	return syscall.SetBpf(p.fd, assembleBpfInsn(append(base, filter...)))
 }
 
+// SetBPFDirection controls whether inbound, or inbound and outbound packets are returned.
+func (p *packetConn) SetBPFDirection(direction int) error {
+	return p.setBPFDirection(p.fd, direction)
+}
+
 // SetPromiscuous enables or disables promiscuous mode on the interface, allowing it
 // to receive traffic that is not addressed to the interface.
 func (p *packetConn) SetPromiscuous(b bool) error {

--- a/raw_linux.go
+++ b/raw_linux.go
@@ -233,6 +233,11 @@ func (p *packetConn) SetBPF(filter []bpf.RawInstruction) error {
 	return nil
 }
 
+// SetBPFDirection is not currently implemented on this platform.
+func (p *packetConn) SetBPFDirection(direction int) error {
+	return ErrNotImplemented
+}
+
 // SetPromiscuous enables or disables promiscuous mode on the interface, allowing it
 // to receive traffic that is not addressed to the interface.
 func (p *packetConn) SetPromiscuous(b bool) error {

--- a/raw_others.go
+++ b/raw_others.go
@@ -62,6 +62,11 @@ func (p *packetConn) SetBPF(filter []bpf.RawInstruction) error {
 	return ErrNotImplemented
 }
 
+// SetBPFDirection is not currently implemented on this platform.
+func (p *packetConn) SetBPFDirection(direction int) error {
+	return ErrNotImplemented
+}
+
 // SetPromisc is not currently implemented on this platform.
 func (p *packetConn) SetPromiscuous(b bool) error {
 	return ErrNotImplemented


### PR DESCRIPTION
This PR exports a SetBPFDirection function, which allows this package to be used to capture outbound packets (the default is to only limit to inbound). 

An alternative implementation would be to pass the direction flag as a member of the Config struct and set it in listenPacket().