### PR TITLE
Provide a BPFDirection Config member for BSD

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -153,4 +153,9 @@ type Config struct {
 	// Linux only: initial filter to apply to the connection. This avoids
 	// capturing random packets before SetBPF is called.
 	Filter []bpf.RawInstruction
+
+	// BSD only: configure the BPF direction flag to allow selection of inbound
+	// only (0 - default) or bidirectional (1) packet processing.
+	// Has no effect on other operating systems.
+	BPFDirection int
 }


### PR DESCRIPTION
This PR adds the BPFDirection member to the Config structure and uses it to set the BPF direction for raw sockets on BSD-like operating systems. The default value of 0 preserves the previous behavior of only receiving inbound packets.