### PR TITLE
Increase potential BFP devices from 11 to 256

### DIFF
--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -63,7 +63,7 @@ func listenPacket(ifi *net.Interface, proto uint16, cfg Config) (*packetConn, er
 	var err error
 
 	// Try to find an available BPF device
-	for i := 0; i <= 10; i++ {
+	for i := 0; i <= 255; i++ {
 		bpfPath := fmt.Sprintf("/dev/bpf%d", i)
 		f, err = os.OpenFile(bpfPath, os.O_RDWR, 0666)
 		if err == nil {


### PR DESCRIPTION
My Darwin BSD has devices bpf0,1 and then only bpf10 available in this range.
With other processes taking up some sockets I'm running into an `unable to open BPF device` at times.

I do however have room to go up to 256 BPF devices available. So this PR is a suggestion to take it up from 0 to 255 to find the first available device.

```
➜  /dev ls | grep bpf | wc -l
     256
```

Alternatively a file listing could be done in the directory prior to setting the for loop limit.

Thank you for considering