### PR TITLE
Allow non-ethernet interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hdm/raw
+module github.com/mdlayher/raw
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mdlayher/raw
+module github.com/hdm/raw
 
 go 1.12
 


### PR DESCRIPTION
This PR removes the strict length checking of the hardware address length, this is necessary to use other link types (for example, a `tun0` interface from OpenVPN). 