### PR TITLE
raw: Remove length-check of HW addr

### DIFF
--- a/raw_linux.go
+++ b/raw_linux.go
@@ -141,7 +141,7 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 
 	// Retrieve hardware address and other information from addr.
 	sa, ok := addr.(*unix.SockaddrLinklayer)
-	if !ok || sa.Halen < 6 {
+	if !ok {
 		return n, nil, unix.EINVAL
 	}
 
@@ -163,7 +163,7 @@ func (p *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 func (p *packetConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 	// Ensure correct Addr type.
 	a, ok := addr.(*Addr)
-	if !ok || a.HardwareAddr == nil || len(a.HardwareAddr) < 6 {
+	if !ok || a.HardwareAddr == nil {
 		return 0, unix.EINVAL
 	}
 

--- a/raw_linux_test.go
+++ b/raw_linux_test.go
@@ -92,9 +92,7 @@ func Test_packetConnReadFromRecvfromInvalidHardwareAddr(t *testing.T) {
 	p, err := newPacketConn(
 		&net.Interface{},
 		&addrRecvfromSocket{
-			addr: &unix.SockaddrLinklayer{
-				Halen: 5,
-			},
+			addr: nil,
 		},
 		0,
 		nil,
@@ -187,8 +185,6 @@ func Test_packetConnWriteToInvalidSockaddr(t *testing.T) {
 
 func Test_packetConnWriteToInvalidHardwareAddr(t *testing.T) {
 	addrs := []net.HardwareAddr{
-		// Too short.
-		{0xde, 0xad, 0xbe, 0xef, 0xde},
 		// Explicitly nil.
 		nil,
 	}


### PR DESCRIPTION
This allows non-Ethernet packets to be handled.

Fixes #57