### PR TITLE
add setMulticast function

### DIFF
--- a/raw.go
+++ b/raw.go
@@ -90,6 +90,11 @@ func (c *Conn) SetPromiscuous(b bool) error {
 	return c.p.SetPromiscuous(b)
 }
 
+// SetMulticast will attach a link-layer multicast address to listen on the interface
+func (c *Conn) SetMulticast(addr net.Addr) error {
+	return c.p.SetMulticast(addr)
+}
+
 // Stats contains statistics about a Conn.
 type Stats struct {
 	// The total number of packets received.

--- a/raw_bsd.go
+++ b/raw_bsd.go
@@ -222,6 +222,11 @@ func (p *packetConn) SetPromiscuous(b bool) error {
 	return syscall.SetBpfPromisc(p.fd, m)
 }
 
+// SetMulticast is not currently implemented on this platform.
+func (p *packetConn) SetMulticast(addr net.Addr) error {
+	return ErrNotImplemented
+}
+
 // Stats retrieves statistics from the Conn.
 func (p *packetConn) Stats() (*Stats, error) {
 	return nil, ErrNotImplemented

--- a/raw_linux.go
+++ b/raw_linux.go
@@ -248,6 +248,30 @@ func (p *packetConn) SetPromiscuous(b bool) error {
 	return p.s.SetSockoptPacketMreq(unix.SOL_PACKET, membership, &mreq)
 }
 
+// SetMulticast will attach a link-layer multicast address to listen on the interface
+func (p *packetConn) SetMulticast(addr net.Addr) error {
+	// Ensure correct Addr type.
+	a, ok := addr.(*Addr)
+	if !ok || a.HardwareAddr == nil {
+		return unix.EINVAL
+	}
+
+	// Convert hardware address back to byte array form.
+	var baddr [8]byte
+	copy(baddr[:], a.HardwareAddr)
+
+	mreq := unix.PacketMreq{
+		Ifindex: int32(p.ifi.Index),
+		Type:    unix.PACKET_MR_MULTICAST,
+		Alen:    uint16(len(a.HardwareAddr)),
+		Address: baddr,
+	}
+
+	membership := unix.PACKET_ADD_MEMBERSHIP
+
+	return p.s.SetSockoptPacketMreq(unix.SOL_PACKET, membership, &mreq)
+}
+
 // Stats retrieves statistics from the Conn.
 func (p *packetConn) Stats() (*Stats, error) {
 	stats, err := p.s.GetSockoptTpacketStats(unix.SOL_PACKET, unix.PACKET_STATISTICS)

--- a/raw_others.go
+++ b/raw_others.go
@@ -65,6 +65,11 @@ func (p *packetConn) SetPromiscuous(b bool) error {
 	return ErrNotImplemented
 }
 
+// SetMulticast is not currently implemented on this platform.
+func (p *packetConn) SetMulticast(addr net.Addr) error {
+	return ErrNotImplemented
+}
+
 // Stats is not currently implemented on this platform.
 func (p *packetConn) Stats() (*Stats, error) {
 	return nil, ErrNotImplemented


### PR DESCRIPTION
This allows the interface to subscribe to a link-layer multicast address.

I've written a small program to proxy eap packets from one interface to another. EAP (802.1x Auth) packets are sent to a link-layer multicast address. The Interface must either subscribe to the Multicast Address or be put in promisc mode. https://github.com/pyther/goeap_proxy/

I wanted to put this out there as a starting point for discussion. Let me know what you think. Not sure if this is the best way to accomplish this? Maybe exposing `SetSockoptPacketMreq` to raw.conn is some capacity would allow for more flexibility?
