### PR TITLE
raw: avoid leaking sock fd if unix.SetNonblock fails in listenPacket

### DIFF
--- a/raw_linux.go
+++ b/raw_linux.go
@@ -73,6 +73,7 @@ func listenPacket(ifi *net.Interface, proto uint16, cfg Config) (*packetConn, er
 	}
 
 	if err := unix.SetNonblock(sock, true); err != nil {
+		unix.Close(sock)
 		return nil, err
 	}
 


### PR DESCRIPTION
At this point, the sock fd is not yet wrapped in an *os.File, so it
needs to be closed explicitly on error.