### PR TITLE
builder: update OpenBSD image to 6.8

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,4 +1,4 @@
-image: openbsd/6.5
+image: openbsd/6.8
 packages:
   - go
 sources:


### PR DESCRIPTION
According to https://man.sr.ht/builds.sr.ht/compatibility.md#openbsd the
OpenBSD 6.5 is no longer available. Bump the image to the latest OpenBSD
version 6.8.