### PR TITLE
raw: return poller error from Recvfrom on i/o timeout

### DIFF
--- a/raw_linux.go
+++ b/raw_linux.go
@@ -341,10 +341,10 @@ func (s *sysSocket) Recvfrom(p []byte, flags int) (n int, addr unix.Sockaddr, er
 		// If the socket is in blocking mode, EAGAIN should never occur.
 		return err != unix.EAGAIN
 	})
-	if err != nil {
-		return n, addr, err
+	if cerr != nil {
+		return n, addr, cerr
 	}
-	return n, addr, cerr
+	return n, addr, err
 }
 
 func (s *sysSocket) Sendto(p []byte, flags int, to unix.Sockaddr) error {


### PR DESCRIPTION
sysSocket.Recvfrom currently returns the error from the syscall instead of
the error from RawConn.Read. This is problematic when using SetReadDeadline.

    cerr := s.rc.Read(func(fd uintptr) bool {
        n, addr, err = unix.Recvfrom(int(fd), p, flags) // err == EAGAIN
        return err != unix.EAGAIN                       // return false
    })
    // Since we return false we enter the poller, Read blocks until
    // deadline elapses. cerr is an i/o timeout now.
    if err != nil {         // err is still EAGAIN from call to read
        return n, addr, err // return EAGAIN instead of i/o timeout
    }

The fix is to prefer returning cerr over err.